### PR TITLE
add get-last-rec-from-host

### DIFF
--- a/scripts/get-last-rec-from-host
+++ b/scripts/get-last-rec-from-host
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -euo pipefail
+
+source env-prep
+
+use_aggregate_search() {
+    local starttime=${1:-"3h"}
+    local hostquery=$( mktemp )
+    cat > $hostquery <<EOF
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": {
+          "range": {
+            "@timestamp": { "gte": "now-${starttime}" }
+         }
+      }
+    }
+  },
+  "aggs": {
+    "hosts": {
+      "terms": {
+        "size": 40,
+        "field": "hostname",
+         "order": [
+             { "last_update": "desc" },
+             { "_term": "asc" }
+          ]
+      },
+      "aggs": {
+        "last_update": {
+          "max": { "field": "@timestamp" }
+        }
+     }
+    }
+  }
+}
+EOF
+    trap "rm -f $hostquery" RETURN
+    local hostqueryres=$( mktemp )
+    cat $hostquery | \
+        oc exec -c elasticsearch -i $pod -- es_util --query=.operations.*,project.*/_search -X POST --data-binary @- > $hostqueryres
+    trap "rm -f $hostquery $hostqueryres" RETURN
+    cat $hostqueryres | python -c 'import sys,json
+from datetime import datetime,timedelta
+from calendar import timegm
+warnthresh = timedelta(minutes=int(sys.argv[1]))
+errthresh = timedelta(minutes=int(sys.argv[2]))
+now = datetime.utcnow()
+hsh = json.load(sys.stdin)
+for bucket in hsh["aggregations"]["hosts"]["buckets"]:
+  recs = bucket["doc_count"]
+  hn = bucket["key"]
+  tsflt = bucket["last_update"]["value"]
+  ts = datetime.utcfromtimestamp(tsflt/1000.0)
+  if now - ts > errthresh:
+    status = "red   "
+  elif now - ts > warnthresh:
+    status = "yellow"
+  else:
+    status = "green "
+  print "{}: {} diff {} records {}".format(status, hn, now-ts, recs)
+print "Date: {} time_t: {} Number of hosts: {}".format(now.isoformat(), timegm(now.timetuple()), len(hsh["aggregations"]["hosts"]["buckets"]))
+' 10 20
+}
+
+use_aggregate_search ${OLDEST:-3h}


### PR DESCRIPTION
This script will show when the last record from each host was
stored in Elasticsearch, along with the count of records from
that host.  It performs an aggregate search by the `"hostname"`
field, which is usually the Kubernetes nodename.

The output looks like this:
```
green : mynode.compute.internal diff 0:00:04.773011 records 50695
```
This means that the last record from node `mynode.compute.internal`
has a `@timestamp` value of 4.77 seconds ago, and that 50695
records have been received in the time interval of the search.

By default, it will go back 3 hours.  Use the env. var. `OLDEST`
to change the time interval e.g.
```
OLDEST=24h ./get-last-rec-from-host
```
to view the past day, or
```
OLDEST=15m ./get-last-rec-from-host
```
to view the last 15 minutes