### PR TITLE
Fixes pods query on env-prep file

### DIFF
--- a/scripts/env-prep
+++ b/scripts/env-prep
@@ -10,5 +10,5 @@ fi
 
 export LOGGING_NS=${LOGGING_NS:-openshift-logging}
 if [ -z "${pod:-}" ] ; then
-  pod=$(oc -n $LOGGING_NS get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
+  pod=$(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
 fi


### PR DESCRIPTION
The command pod=$(oc -n $LOGGING_NS get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) 

should be:

pod=$(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name})

There is a typo error on the command.